### PR TITLE
1. Add toHexStr to fix the bug in hashing small integer in JS, as hash(2...

### DIFF
--- a/lib/jsbn.js
+++ b/lib/jsbn.js
@@ -691,6 +691,16 @@ function bnToByteArray() {
   return r;
 }
 
+function bnToByteArrayUnsigned() {
+  var byteArray = this.toByteArray(),
+	  byteArrayUnsigned = [],
+	  len = byteArray.length,
+	  i = 0;
+  for( ; i < len; i++)
+	byteArrayUnsigned.push(byteArray[i] < 0 ? byteArray[i] + 256 : byteArray[i]);
+  return byteArrayUnsigned;
+}
+
 function bnEquals(a) { return(this.compareTo(a)==0); }
 function bnMin(a) { return(this.compareTo(a)<0)?this:a; }
 function bnMax(a) { return(this.compareTo(a)>0)?this:a; }
@@ -1175,6 +1185,7 @@ BigInteger.prototype.byteValue = bnByteValue;
 BigInteger.prototype.shortValue = bnShortValue;
 BigInteger.prototype.signum = bnSigNum;
 BigInteger.prototype.toByteArray = bnToByteArray;
+BigInteger.prototype.toByteArrayUnsigned = bnToByteArrayUnsigned;
 BigInteger.prototype.equals = bnEquals;
 BigInteger.prototype.min = bnMin;
 BigInteger.prototype.max = bnMax;

--- a/src/srp-client.js
+++ b/src/srp-client.js
@@ -264,6 +264,16 @@ SRPClient.prototype = {
    return hash.mod(this.N);
 
   },
+  
+  /*
+   * Convert a BigInteger to a hex string beginning with 0x
+   * as Hash(2) != Hash('2') != Hash(0x02) != Hash(0x2) in sjcl
+   */
+  hexStr: function(bigInt) {
+	var hex = bigInt.toString(16),
+        prefix = (hex.length < 2) ? '0x0' : '0x';
+    return prefix + hex;
+  },
 
   /* 
    * Generic hashing function.
@@ -291,9 +301,7 @@ SRPClient.prototype = {
     switch (this.hashFn.toLowerCase()) {
 
       case 'sha-256':
-        var s = sjcl.codec.hex.fromBits(
-                sjcl.hash.sha256.hash(
-                sjcl.codec.hex.toBits(str)));
+        var s = this.hash(sjcl.codec.hex.toBits(str));
         return this.nZeros(64 - s.length) + s;
 
       case 'sha-1':
@@ -302,6 +310,14 @@ SRPClient.prototype = {
 
     }
   },
+  
+  /*
+   * string hashing function, translated to utf and hash. 
+   */
+  utfHash: function (str) {
+	return this.hash(sjcl.codec.utf8String.toBits(str));
+  },
+  
   
   /*
    * Hex to string conversion.


### PR DESCRIPTION
...) != hash(0x02) != hash(0x2); 2. Add bnToByteArrayUnsigned to translate the big integer to _unsigned_ byte array.
1. Add utfHash, abc should be hash('abc'), hexHash('0x616263'), or utfHash('abc')

'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad'
1. Add hexStr to convert a small integer to a %02X, if srp.g is 2, it will be converted to 0x02, instead of 0x2. 

-- if we need to hash integer 2, we should convert it to 0x02 and hash 0x02, it should be hexHash(0x02)

dbc1b4c900ffe48d575b5da5c638040125f65db0fe3e24494b76ea986457d986

however, srp.hexHash(srp.two.toString(16)) gives me '21e3aac0017e45efb3bb4a7022e3aa5b01e6e1e703ab7bf71d12c19f6f4d6658' (sha-256), which is 0x2
1. Add bnToByteArrayUnsigned
